### PR TITLE
Updates `compileSdkVersion` declaration for AndroidX support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Hello Osama,

Thanks for the library! I noticed that your `compileSdkVersion` declaration still targets `27` and not `28` as it should [since the AndroidX upgrade](https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility#fixing-androidx-crashes-in-a-flutter-app).

It was breaking my app compilation, so I used the plugin from my fork in my pubspec.yaml, and it fixed the errors.