### PR TITLE
Fixes Exception thrown when not executing in an activity

### DIFF
--- a/android/src/main/java/com/cloudsoft/simservice/SimServicePlugin.java
+++ b/android/src/main/java/com/cloudsoft/simservice/SimServicePlugin.java
@@ -240,10 +240,10 @@ public class SimServicePlugin  implements MethodCallHandler {
         ActivityCompat.requestPermissions(activity, perm, 0);
     }
     private boolean checkPermission(String permission) {
-        Activity activity = mRegistrar.activity();
+        Context context = mRegistrar.context();
         permission = getManifestPermission(permission);
         Log.i("SimplePermission", "Checking permission : " + permission);
-        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(activity, permission);
+        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(context, permission);
     }
 
 


### PR DESCRIPTION
Hello Osama,

The signature of ContextCompat.checkSelfPermission is so that its first parameter is a `Context` and not an `Activity`, as documented [here](https://developer.android.com/reference/android/support/v4/content/ContextCompat.html#checkSelfPermission(android.content.Context,%20java.lang.String))

The current value passed (an `Activity`) leads to a crash when executing in an alarm callback for example.